### PR TITLE
Improve paths handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ notify = "5.0.0-pre.4"
 
 bincode = "1.3.1"
 
+# Save directories
+dirs = "3.0"
+
 [dependencies.glam]
 version = "0.9.5"
 features = ["serde"]

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -2,6 +2,7 @@ use crate::assets::audio::Audio;
 use crate::assets::prefab::PrefabManager;
 use crate::assets::shader::ShaderManager;
 use crate::assets::sprite::SpriteAsset;
+use crate::paths::get_assets_path;
 use crate::resources::Resources;
 use bitflags::_core::marker::PhantomData;
 use log::debug;
@@ -11,7 +12,6 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::hash_map::Keys;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
@@ -25,7 +25,7 @@ pub fn create_asset_managers<S>(_surface: &mut S, resources: &mut Resources)
 where
     S: GraphicsContext<Backend = GL33> + 'static,
 {
-    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+    let base_path = get_assets_path();
 
     #[cfg(not(feature = "packed"))]
     let sprite_manager: AssetManager<S, SpriteAsset<S>> = AssetManager::from_loader(Box::new(
@@ -354,8 +354,7 @@ where
     S: GraphicsContext<Backend = GL33> + 'static,
 {
     pub fn new() -> Self {
-        let base_path =
-            PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+        let base_path = get_assets_path();
 
         let (tx, rx) = std::sync::mpsc::channel();
 

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -25,28 +25,28 @@ pub fn create_asset_managers<S>(_surface: &mut S, resources: &mut Resources)
 where
     S: GraphicsContext<Backend = GL33> + 'static,
 {
-    let base_path = std::env::var("ASSET_PATH").unwrap_or("".to_string());
+    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
 
     #[cfg(not(feature = "packed"))]
     let sprite_manager: AssetManager<S, SpriteAsset<S>> = AssetManager::from_loader(Box::new(
-        sprite::SpriteSyncLoader::new(PathBuf::from(&base_path).join("assets/sprites")),
+        sprite::SpriteSyncLoader::new(base_path.join("sprites")),
     ));
 
     #[cfg(feature = "packed")]
     let sprite_manager: AssetManager<S, SpriteAsset<S>> = AssetManager::from_loader(Box::new(
-        sprite::SpritePackLoader::new(PathBuf::from(&base_path).join("assets/sprites")),
+        sprite::SpritePackLoader::new(base_path.join("sprites")),
     ));
 
     let prefab_loader: PrefabManager<S> = AssetManager::from_loader(Box::new(
-        prefab::PrefabSyncLoader::new(PathBuf::from(&base_path).join("assets/prefab")),
+        prefab::PrefabSyncLoader::new(base_path.join("prefab")),
     ));
 
     let audio_loader: AssetManager<S, Audio> = AssetManager::from_loader(Box::new(
-        audio::AudioSyncLoader::new(PathBuf::from(&base_path).join("assets")),
+        audio::AudioSyncLoader::new(base_path.clone()),
     ));
 
     let shader_loader: ShaderManager<S> = AssetManager::from_loader(Box::new(
-        shader::ShaderLoader::new(PathBuf::from(&base_path).join("assets/shaders")),
+        shader::ShaderLoader::new(base_path.join("shaders")),
     ));
     resources.insert(sprite_manager);
     resources.insert(prefab_loader);
@@ -355,7 +355,7 @@ where
 {
     pub fn new() -> Self {
         let base_path =
-            PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("".to_string())).join("assets");
+            PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
 
         let (tx, rx) = std::sync::mpsc::channel();
 

--- a/src/bin/generate_prefab.rs
+++ b/src/bin/generate_prefab.rs
@@ -12,17 +12,17 @@ use spacegame::gameplay::enemy::{
 use spacegame::gameplay::health::Health;
 use spacegame::gameplay::physics::DynamicBody;
 use spacegame::gameplay::player::{Player, Stats};
+use spacegame::paths::get_assets_path;
 use spacegame::prefab::enemies::EnemyPrefab;
 use spacegame::prefab::player::PlayerPrefab;
 use spacegame::render::particle::ParticleEmitter;
 use spacegame::render::sprite::Sprite;
-use std::path::PathBuf;
 
 fn gen_player() {
     let player = {
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -240,9 +240,9 @@ fn gen_wanderer() {
 fn gen_base_enemy() {
     let base_enemy = {
         let scale = 24.0;
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/enemy_trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/enemy_trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -291,9 +291,9 @@ fn gen_base_enemy() {
 fn gen_carrier() {
     let base_enemy = {
         let scale = 128.0;
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/enemy_trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/enemy_trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -345,9 +345,9 @@ fn gen_carrier() {
 fn gen_kamikaze() {
     let base_enemy = {
         let scale = 20.0;
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/enemy_trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/enemy_trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -396,9 +396,9 @@ fn gen_kamikaze() {
 fn gen_base_enemy_2() {
     let base_enemy = {
         let scale = 24.0;
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/enemy_trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/enemy_trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -447,9 +447,9 @@ fn gen_base_enemy_2() {
 fn gen_base_enemy_3() {
     let base_enemy = {
         let scale = 24.0;
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/enemy_trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/enemy_trail.json"))
                 .unwrap(),
         )
         .unwrap();

--- a/src/gameplay/health.rs
+++ b/src/gameplay/health.rs
@@ -3,13 +3,13 @@ use crate::core::transform::Transform;
 use crate::event::GameEvent;
 use crate::gameplay::enemy::{Enemy, EnemyType};
 use crate::gameplay::player::Player;
+use crate::paths::get_assets_path;
 use crate::render::particle::ParticleEmitter;
 use crate::render::sprite::Blink;
 use crate::resources::Resources;
 use log::{debug, trace};
 use serde_derive::{Deserialize, Serialize};
 use shrev::{EventChannel, ReaderId};
-use std::path::PathBuf;
 use std::time::Duration;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -99,9 +99,9 @@ pub struct HealthSystem {
 
 impl HealthSystem {
     pub fn new(resources: &mut Resources) -> Self {
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(base_path).join("particle/explosion.json"))
+            &std::fs::read_to_string(base_path.join("particle/explosion.json"))
                 .unwrap(),
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod core;
 pub mod event;
 pub mod game;
 pub mod gameplay;
+pub mod paths;
 pub mod prefab;
 pub mod render;
 pub mod resources;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 use log::info;
 use luminance_glfw::GlfwSurface;
 use luminance_windowing::{CursorMode, WindowOpt};
-use std::path::PathBuf;
 use std::process::exit;
 
 use spacegame::game::{Game, GameBuilder};
@@ -11,6 +10,7 @@ use spacegame::config::{load_config, AudioConfig, GameEngineConfig, InputConfig,
 use spacegame::gameplay::inventory::Inventory;
 use spacegame::gameplay::level::difficulty::DifficultyConfig;
 use spacegame::gameplay::Action;
+use spacegame::paths::get_assets_path;
 use spacegame::save::read_saved_data;
 use spacegame::scene::loading::LoadingScene;
 #[allow(unused_imports)]
@@ -40,7 +40,7 @@ fn main_loop(mut surface: GlfwSurface) {
     dotenv::dotenv().ok();
     pretty_env_logger::init();
 
-    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+    let base_path = get_assets_path();
     let player_config_path = base_path.join("config/player_controller.json");
     let player_config: PlayerConfig = load_config(&player_config_path).unwrap_or_else(|e| {
         log::info!("Will use default PlayerConfig because = {:?}", e);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,5 @@
+use std::path::PathBuf;
+
+pub fn get_assets_path() -> PathBuf {
+    PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()))
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,18 @@
+use dirs::data_dir;
 use std::path::PathBuf;
 
 pub fn get_assets_path() -> PathBuf {
     PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()))
+}
+
+pub fn get_save_path() -> PathBuf {
+    if let Some(mut save_dir) = data_dir() {
+        save_dir.push("everfight");
+        if let Err(err) = std::fs::create_dir_all(save_dir.clone()) {
+            error!("Failed to create save directory {}: {}", save_dir.to_string_lossy(), err);
+        }
+        save_dir
+    } else {
+        get_assets_path()
+    }
 }

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,5 +1,5 @@
 use crate::resources::Resources;
-use crate::paths::get_assets_path;
+use crate::paths::get_save_path;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,7 +40,7 @@ pub fn save_new_wave_record(resources: &Resources, new_record: usize) -> Result<
         d.wave_record = new_record;
     }
 
-    let base_path = get_assets_path();
+    let base_path = get_save_path();
     let save_path = base_path.join("data.bin");
     let data = bincode::serialize(&*d)?;
     std::fs::write(save_path, data)?;
@@ -53,7 +53,7 @@ pub fn save_unlocked(resources: &Resources) -> Result<(), anyhow::Error> {
         .expect("Should have SavedData...");
     d.is_infinite_unlocked = true;
 
-    let base_path = get_assets_path();
+    let base_path = get_save_path();
     let save_path = base_path.join("data.bin");
     let data = bincode::serialize(&*d)?;
     std::fs::write(save_path, data)?;
@@ -61,7 +61,7 @@ pub fn save_unlocked(resources: &Resources) -> Result<(), anyhow::Error> {
 }
 
 pub fn read_saved_data() -> SavedData {
-    let base_path = get_assets_path();
+    let base_path = get_save_path();
     let save_path = base_path.join("data.bin");
 
     if let Ok(data) = std::fs::read(&save_path) {

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,6 +1,6 @@
 use crate::resources::Resources;
+use crate::paths::get_assets_path;
 use serde_derive::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SavedData {
@@ -40,7 +40,7 @@ pub fn save_new_wave_record(resources: &Resources, new_record: usize) -> Result<
         d.wave_record = new_record;
     }
 
-    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+    let base_path = get_assets_path();
     let save_path = base_path.join("data.bin");
     let data = bincode::serialize(&*d)?;
     std::fs::write(save_path, data)?;
@@ -53,7 +53,7 @@ pub fn save_unlocked(resources: &Resources) -> Result<(), anyhow::Error> {
         .expect("Should have SavedData...");
     d.is_infinite_unlocked = true;
 
-    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+    let base_path = get_assets_path();
     let save_path = base_path.join("data.bin");
     let data = bincode::serialize(&*d)?;
     std::fs::write(save_path, data)?;
@@ -61,7 +61,7 @@ pub fn save_unlocked(resources: &Resources) -> Result<(), anyhow::Error> {
 }
 
 pub fn read_saved_data() -> SavedData {
-    let base_path = PathBuf::from(std::env::var("ASSET_PATH").unwrap_or("assets/".to_string()));
+    let base_path = get_assets_path();
     let save_path = base_path.join("data.bin");
 
     if let Ok(data) = std::fs::read(&save_path) {

--- a/src/scene/main_menu.rs
+++ b/src/scene/main_menu.rs
@@ -1,6 +1,7 @@
 use crate::core::audio;
 use crate::core::scene::{Scene, SceneResult};
 use crate::core::transform::Transform;
+use crate::paths::get_assets_path;
 use crate::prefab::enemies::ENEMY_PREFABS;
 use crate::render::particle::ParticleEmitter;
 use crate::render::ui::gui::GuiContext;
@@ -15,7 +16,6 @@ use crate::ui::{disabled_menu_button, draw_cursor, menu_button};
 use bitflags::_core::time::Duration;
 use glfw::WindowEvent;
 use hecs::World;
-use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 enum GameMode {
@@ -33,9 +33,9 @@ pub struct MainMenu {
 impl Scene<WindowEvent> for MainMenu {
     fn on_create(&mut self, world: &mut hecs::World, resources: &mut Resources) {
         //generate_terrain(world, resources);
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let emitter = ParticleEmitter::load_from_path(
-            PathBuf::from(&base_path).join("particle").join("menu.json"),
+            base_path.join("particle").join("menu.json"),
         )
         .unwrap();
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -19,6 +19,7 @@ use crate::gameplay::pickup::{process_pickups, spawn_pickup, Pickup};
 use crate::gameplay::player::get_player;
 use crate::gameplay::trail::update_trails;
 use crate::gameplay::{bullet, collision, enemy, player};
+use crate::paths::get_assets_path;
 use crate::render::mesh::{Material, MeshRender};
 use crate::render::particle::ParticleEmitter;
 use crate::render::ui::gui::GuiContext;
@@ -34,7 +35,6 @@ use hecs::World;
 use log::info;
 use luminance_glfw::GlfwSurface;
 use rand::Rng;
-use std::path::PathBuf;
 use std::time::Duration;
 
 pub mod loading;
@@ -103,9 +103,9 @@ impl Scene<WindowEvent> for MainScene {
         self.explosion_system = Some(ExplosionSystem::new(resources));
 
         //generate_terrain(world, resources);
-        let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+        let base_path = get_assets_path();
         let mut emitter: ParticleEmitter = serde_json::from_str(
-            &std::fs::read_to_string(PathBuf::from(&base_path).join("particle/trail.json"))
+            &std::fs::read_to_string(base_path.join("particle/trail.json"))
                 .unwrap(),
         )
         .unwrap();
@@ -114,7 +114,7 @@ impl Scene<WindowEvent> for MainScene {
         let stage_desc: StageDescription = if self.is_infinite {
             StageDescription::infinite()
         } else {
-            let p = PathBuf::from(&base_path).join("stages/stage1.json");
+            let p = base_path.join("stages/stage1.json");
             let content = std::fs::read_to_string(p).unwrap();
             serde_json::from_str(&content).unwrap()
         };
@@ -466,9 +466,9 @@ impl Scene<WindowEvent> for MainScene {
                 self.info_text = Some(info);
             }
             GameEvent::NextStage(stage_name) => {
-                let base_path = std::env::var("ASSET_PATH").unwrap_or("assets/".to_string());
+                let base_path = get_assets_path();
                 let stage_desc: StageDescription = {
-                    let p = PathBuf::from(&base_path).join("stages").join(stage_name);
+                    let p = base_path.join("stages").join(stage_name);
                     let content = std::fs::read_to_string(p).unwrap();
                     serde_json::from_str(&content).unwrap()
                 };


### PR DESCRIPTION
This PR is best reviewed commit per commit.

It allows the game to be installed in a read-only location (which is common for Linux packages) while saving in the expected data location, for instance `~/.local/share/everfight` on Linux.