### PR TITLE
Bump dependencies and remove some unused ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,15 +23,15 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
 
 [[package]]
 name = "anymap"
@@ -116,9 +116,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -161,13 +161,12 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.3"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "lazy_static",
  "lazycell",
@@ -222,9 +221,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cesu8"
@@ -261,9 +260,9 @@ checksum = "7477065d45a8fe57167bf3cf8bcd3729b54cfcb81cca49bda2d038ea89ae82ca"
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
@@ -271,25 +270,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "claxon"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
 dependencies = [
  "cc",
 ]
@@ -315,20 +299,14 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.3.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2809f67365382d65fd2b6d9c22577231b954ed27400efeafbe687bda75abcc0b"
+checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
 dependencies = [
  "bytes",
  "memchr",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
 
 [[package]]
 name = "constant_time_eq"
@@ -364,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f73df0f29f4c3c374854f076c47dc018f19acaa63538880dba0937ad4fa8d7"
+checksum = "2b7e3347be6a09b46aba228d6608386739fb70beff4f61e07422da87b0bb31fa"
 dependencies = [
  "bindgen",
 ]
@@ -416,35 +394,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch 0.8.2",
+ "crossbeam-epoch",
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -463,20 +420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-epoch"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,13 +432,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -511,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "15d658711a12632b5574c8d5b3fc5d2f0d2f87b9fbf9237ee0f759b88bb6bdec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -521,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "16d3514d243331d8acde56bfcf45d0147aabbda853c2f49dce081ea85f9a7220"
 dependencies = [
  "fnv",
  "ident_case",
@@ -535,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "44f63c369ef0c17ad17585d31d5f2bf10dece2710bf0766e01db57a6f9849a2e"
 dependencies = [
  "darling_core",
  "quote",
@@ -741,16 +683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02efba560f227847cb41463a7395c514d127d4f74fff12ef0137fff1b84b96c4"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,18 +710,19 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.9.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8637c7ec4fd0776c51eeab3e0d5d1aa7e440ece3fc2ee7d674e13c957287bfc1"
+checksum = "bef81f244b2a421ddb8ccb382857772379c0996fe5948992db5bee51cef3c28e"
 dependencies = [
  "serde",
+ "version_check",
 ]
 
 [[package]]
 name = "glfw"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985f851b0d032911e199f308689d25c71f79d12c44625c3a31b683ad4e4f5dd9"
+checksum = "dbb254ad1715644ab078c94372405bf061358b97969635ef7b09cf6f9437843e"
 dependencies = [
  "bitflags",
  "glfw-sys",
@@ -851,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "hecs"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab00cb6b57ddcf099e2e7ad770f9fe5d8f76b5797dd43ac71ed7caef13283937"
+checksum = "2fc21f4816c4332a954ac0b7a227f1a06a0addd8f240c2727591449f56de5931"
 dependencies = [
  "hashbrown",
 ]
@@ -912,21 +845,17 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0a8345b33b082aedec2f4d7d4a926b845cee184cbe78b703413066564431b"
+checksum = "7ce04077ead78e39ae8610ad26216aed811996b043d47beed5090db674f9e9b5"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "gif",
- "jpeg-decoder",
  "num-iter",
  "num-rational",
  "num-traits",
  "png",
- "scoped_threadpool",
- "tiff",
 ]
 
 [[package]]
@@ -951,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1016,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36bcc950632e48b86da402c5c077590583da5ac0d480103611d5374e7c967a3c"
 dependencies = [
  "cesu8",
- "combine 4.3.2",
+ "combine 4.4.0",
  "error-chain",
  "jni-sys",
  "log",
@@ -1030,20 +959,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc797adac5f083b8ff0ca6f6294a999393d76e197c36488e2ef732c4715f6fa3"
-dependencies = [
- "byteorder",
- "rayon",
-]
-
-[[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1077,21 +996,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "lewton"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be42bea7971f4ba0ea1e215730c29bc1ff9bd2a9c10013912f42a8dcf8d77c0d"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec 0.3.4",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libflate"
@@ -1107,11 +1015,11 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
 
@@ -1141,15 +1049,18 @@ dependencies = [
 
 [[package]]
 name = "luminance"
-version = "0.42.1"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197dba76d6bce43595879aa6509dd0499cc8659ad230fcd7f3d753ccdfb318ec"
+checksum = "af90d32ad2eea97a3e55d111f19348bda92855b6220dc77ef5b7dbbabaefa3af"
+dependencies = [
+ "luminance-derive",
+]
 
 [[package]]
 name = "luminance-derive"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a81163c4bbc31b829b36d7787f2c15ed63bac6baefd5b00a33fc0d12b5b683f"
+checksum = "bdd6b8d5743d7d434bda65a0657d699051aba986af7a9eebadff382f399f1c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1158,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "luminance-gl"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4b6ddc4f46ce418d0a6b7c39c475db9c238b8fecf5087d83a763a9f00944d0"
+checksum = "9ec6224c577c680462316d3106170cc33949384aca8abe7e5c0496d2d333e1eb"
 dependencies = [
  "gl",
  "luminance",
@@ -1168,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "luminance-glfw"
-version = "0.14.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f73c3e27cfdc20a9d470073592ecfea0dbaf853ab1c2179ed2a739e8d575ec"
+checksum = "4927a57b785e6746a1ce2eee125f3420255caf013ed04abc187752ec984d8291"
 dependencies = [
  "gl",
  "glfw",
@@ -1181,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "luminance-windowing"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8956347c23ccce8f7f5ae2d266f3e73dfa78c3ac049ff99b7c37b3df2e66d3"
+checksum = "a25a647991bc5c9f35a1aa6d506492457c105f9180e2af84270dc0b8b9929704"
 dependencies = [
  "luminance",
 ]
@@ -1270,16 +1181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -1330,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1361,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1418,9 +1323,9 @@ checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1458,7 +1363,7 @@ checksum = "a8b946889dfdad884379cd56367d93b6d0ce8889cc027d26a69a3a31c0a03bb5"
 dependencies = [
  "anymap",
  "bitflags",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "filetime",
  "fsevent",
  "fsevent-sys",
@@ -1483,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1493,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1504,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1515,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1571,9 +1476,9 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "oboe"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a13c9fe73346ff3cee5530b8dd9da1ce3e13cb663be210af3938a2a1dd3eab"
+checksum = "1aadc2b0867bdbb9a81c4d99b9b682958f49dbea1295a81d2f646cca2afdd9fc"
 dependencies = [
  "jni 0.14.0",
  "ndk",
@@ -1593,15 +1498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ogg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79f1db9148be9d0e174bb3ac890f6030fcb1ed947267c5a91ee4c91b5a91e15"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,9 +1505,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "ordered-float"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
 ]
@@ -1629,12 +1525,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1674,9 +1569,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "png"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe7f9f1c730833200b134370e1d5098964231af8450bce9b78ee3ab5278b970"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -1686,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "pretty_env_logger"
@@ -1793,31 +1688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
-dependencies = [
- "autocfg",
- "crossbeam-deque 0.8.0",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
-dependencies = [
- "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1848,15 +1718,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -1879,10 +1749,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9683532495146e98878d4948fa1a1953f584cd923f2a5f5c26b7a8701b56943"
 dependencies = [
- "claxon",
  "cpal",
  "hound",
- "lewton",
  "minimp3",
 ]
 
@@ -1895,7 +1763,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils 0.8.1",
 ]
 
 [[package]]
@@ -1930,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f61411055101f7b60ecf1041d87fb74205fb20b0c7a723f07ef39174cf6b4c0"
 dependencies = [
  "approx",
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque",
  "crossbeam-utils 0.7.2",
  "linked-hash-map",
  "num_cpus",
@@ -1953,12 +1821,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -1993,18 +1855,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2013,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -2062,16 +1924,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "spacegame"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
  "bincode",
  "bitflags",
  "dirs",
@@ -2089,7 +1950,6 @@ dependencies = [
  "luminance-glfw",
  "luminance-windowing",
  "lyon",
- "md5",
  "notify",
  "pretty_env_logger",
  "rand",
@@ -2131,15 +1991,15 @@ checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2166,27 +2026,27 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2203,17 +2063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abeb4e3f32a8973722c0254189e6890358e72b1bf11becb287ee0b23c595a41d"
-dependencies = [
- "jpeg-decoder",
- "miniz_oxide 0.4.3",
- "weezl",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,15 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
-
-[[package]]
-name = "tinyvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2300,11 +2143,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
- "tinyvec 1.0.1",
+ "tinyvec",
 ]
 
 [[package]]
@@ -2405,19 +2248,19 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2430,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2440,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2453,15 +2296,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2469,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -2485,12 +2328,6 @@ checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8795d6e0e17485803cc10ef126bb8c0d59b7c61b219d66cfe0b3216dd0e8580a"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ default-run = "spacegame"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-luminance = "0.42"
+luminance = "0.43"
 luminance-glfw = "0.14"
-luminance-gl = "0.15.0"
+luminance-gl = "0.16"
 luminance-windowing = "0.9"
 luminance-derive = "0.6"
-glfw = "0.40"
-image = "0.23.11"
+glfw = "0.41"
+image = "0.23.12"
 
 # ecs
-hecs = "0.2.15"
+hecs = "0.3"
 
 bitflags = "1.2.1"
 downcast-rs = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ luminance-gl = "0.16"
 luminance-windowing = "0.9"
 luminance-derive = "0.6"
 glfw = "0.41"
-image = "0.23.12"
+image = { version = "0.23.12", default-features = false, features = ["png"] }
 
 # ecs
 hecs = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ typetag = "0.1"
 anyhow = "1.0.34"
 
 # Sound
-rodio = "0.13.0"
+rodio = { version = "0.13.0", default-features = false, features = ["wav", "mp3"] }
 
 # hash for assets' ID
 md5 = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bincode = "1.3.1"
 dirs = "3.0"
 
 [dependencies.glam]
-version = "0.9.5"
+version = "0.11"
 features = ["serde"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,6 @@ anyhow = "1.0.34"
 # Sound
 rodio = { version = "0.13.0", default-features = false, features = ["wav", "mp3"] }
 
-# hash for assets' ID
-md5 = "0.7.0"
-base64 = "0.13.0"
-
 # hot reload for assets
 notify = "5.0.0-pre.4"
 

--- a/src/assets/sprite.rs
+++ b/src/assets/sprite.rs
@@ -275,7 +275,7 @@ impl DepthComparisonDef {
 }
 
 pub fn load_texels<P: AsRef<Path>>(path: P) -> Result<(u32, u32, Vec<u8>), ImageError> {
-    let img = image::open(path).map(|img| img.flipv().to_rgba())?;
+    let img = image::open(path).map(|img| img.flipv().to_rgba8())?;
     let (width, height) = img.dimensions();
     Ok((width, height, img.into_raw()))
 }

--- a/src/core/camera.rs
+++ b/src/core/camera.rs
@@ -43,7 +43,7 @@ pub fn screen_to_world(
     let pv = projection_matrix * view;
     let inv = pv.inverse();
     let mouse_pos_world = inv * screen_coords.extend(0.0).extend(1.0);
-    glam::vec2(mouse_pos_world.x(), mouse_pos_world.y())
+    glam::vec2(mouse_pos_world.x, mouse_pos_world.y)
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -97,8 +97,8 @@ where
 
     pub fn mouse_position(&self) -> glam::Vec2 {
         glam::vec2(
-            (self.mouse_pos.x() / WIDTH as f32) * 2.0 - 1.0,
-            ((HEIGHT as f32 - self.mouse_pos.y()) / HEIGHT as f32) * 2.0 - 1.0,
+            (self.mouse_pos.x / WIDTH as f32) * 2.0 - 1.0,
+            ((HEIGHT as f32 - self.mouse_pos.y) / HEIGHT as f32) * 2.0 - 1.0,
         )
     }
 }

--- a/src/core/transform.rs
+++ b/src/core/transform.rs
@@ -155,7 +155,7 @@ pub fn update_transforms(world: &mut hecs::World) {
 
 /// assume scale is always 1 to simplify. Only true in that specific case of course.
 fn decompose_mat3(mat: Mat3) -> (f32, Vec2) {
-    let translation = glam::vec2(mat.z_axis().x(), mat.z_axis().y());
-    let angle = mat.x_axis().y().atan2(mat.x_axis().x());
+    let translation = glam::vec2(mat.z_axis.x, mat.z_axis.y);
+    let angle = mat.x_axis.y.atan2(mat.x_axis.x);
     (angle, translation)
 }

--- a/src/gameplay/bullet.rs
+++ b/src/gameplay/bullet.rs
@@ -95,10 +95,10 @@ pub fn process_missiles(world: &World, resources: &Resources) {
             body.add_force(body.velocity.normalize() * body.max_velocity);
         }
 
-        if t.translation.x() > max_width
-            || t.translation.x() < -max_width
-            || t.translation.y() > max_height
-            || t.translation.y() < -max_height
+        if t.translation.x > max_width
+            || t.translation.x < -max_width
+            || t.translation.y > max_height
+            || t.translation.y < -max_height
         {
             to_despawn.push(GameEvent::Delete(e));
         }
@@ -123,10 +123,10 @@ pub fn process_bullets(world: &World, resources: &Resources) {
     for (e, (b, t)) in world.query::<(&Bullet, &mut Transform)>().iter() {
         t.translation += b.direction * b.speed;
 
-        if t.translation.x() > max_width
-            || t.translation.x() < -max_width
-            || t.translation.y() > max_height
-            || t.translation.y() < -max_height
+        if t.translation.x > max_width
+            || t.translation.x < -max_width
+            || t.translation.y > max_height
+            || t.translation.y < -max_height
         {
             to_despawn.push(GameEvent::Delete(e));
         }

--- a/src/gameplay/camera.rs
+++ b/src/gameplay/camera.rs
@@ -16,9 +16,9 @@ pub fn update_camera(world: &mut World, resources: &Resources) {
         if let Some((_, t)) = world.query::<&mut Camera>().iter().next() {
             t.position = pos; // - glam::vec2(WIDTH as f32 / 2.0, HEIGHT as f32 / 2.0);
             t.position
-                .set_x((t.position.x().max(-800.0)).min(800.0) - dim.width as f32 / 2.0);
+                .x = (t.position.x.max(-800.0)).min(800.0) - dim.width as f32 / 2.0;
             t.position
-                .set_y(t.position.y().max(-450.0).min(450.0) - dim.height as f32 / 2.0);
+                .y = t.position.y.max(-450.0).min(450.0) - dim.height as f32 / 2.0;
         }
     }
 }

--- a/src/gameplay/collision.rs
+++ b/src/gameplay/collision.rs
@@ -154,7 +154,7 @@ impl BoundingBox {
     fn is_point_inside(&self, position: glam::Vec2, point: glam::Vec2) -> bool {
         let min = position - self.half_extend;
         let max = position + self.half_extend;
-        point.x() >= min.x() && point.x() <= max.x() && point.y() >= min.y() && point.y() <= max.y()
+        point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y
     }
 
     fn collide_with_circle(&self, position: glam::Vec2, circle: Circle) -> bool {
@@ -165,10 +165,10 @@ impl BoundingBox {
 
         // If any edge in circle, that's a collision.
         let edge1 = position - self.half_extend;
-        let edge2 = position - self.half_extend.x() * glam::Vec2::unit_x()
-            + self.half_extend.y() * glam::Vec2::unit_y();
-        let edge3 = position + self.half_extend.x() * glam::Vec2::unit_x()
-            - self.half_extend.y() * glam::Vec2::unit_y();
+        let edge2 = position - self.half_extend.x * glam::Vec2::unit_x()
+            + self.half_extend.y * glam::Vec2::unit_y();
+        let edge3 = position + self.half_extend.x * glam::Vec2::unit_x()
+            - self.half_extend.y * glam::Vec2::unit_y();
         let edge4 = position + self.half_extend;
 
         circle.is_point_inside(edge1)
@@ -281,14 +281,14 @@ pub fn find_collisions(world: &World, resources: &Resources) -> Vec<(Entity, Ent
                 continue;
             }
 
-            if transform1.translation.x() - bb1.half_extend.x()
-                < transform2.translation.x() + bb2.half_extend.x()
-                && transform1.translation.x() + bb1.half_extend.x()
-                    > transform2.translation.x() - bb2.half_extend.x()
-                && transform1.translation.y() - bb1.half_extend.y()
-                    < transform2.translation.y() + bb2.half_extend.y()
-                && transform1.translation.y() + bb1.half_extend.y()
-                    > transform2.translation.y() - bb2.half_extend.y()
+            if transform1.translation.x - bb1.half_extend.x
+                < transform2.translation.x + bb2.half_extend.x
+                && transform1.translation.x + bb1.half_extend.x
+                    > transform2.translation.x - bb2.half_extend.x
+                && transform1.translation.y - bb1.half_extend.y
+                    < transform2.translation.y + bb2.half_extend.y
+                && transform1.translation.y + bb1.half_extend.y
+                    > transform2.translation.y - bb2.half_extend.y
             {
                 // if collision, let's draw the quads :)
                 debug::stroke_quad(
@@ -320,14 +320,14 @@ pub fn aabb_intersection(
     transform2: &Transform,
     bb2: &BoundingBox,
 ) -> bool {
-    transform1.translation.x() - bb1.half_extend.x()
-        < transform2.translation.x() + bb2.half_extend.x()
-        && transform1.translation.x() + bb1.half_extend.x()
-            > transform2.translation.x() - bb2.half_extend.x()
-        && transform1.translation.y() - bb1.half_extend.y()
-            < transform2.translation.y() + bb2.half_extend.y()
-        && transform1.translation.y() + bb1.half_extend.y()
-            > transform2.translation.y() - bb2.half_extend.y()
+    transform1.translation.x - bb1.half_extend.x
+        < transform2.translation.x + bb2.half_extend.x
+        && transform1.translation.x + bb1.half_extend.x
+            > transform2.translation.x - bb2.half_extend.x
+        && transform1.translation.y - bb1.half_extend.y
+            < transform2.translation.y + bb2.half_extend.y
+        && transform1.translation.y + bb1.half_extend.y
+            > transform2.translation.y - bb2.half_extend.y
 }
 
 pub fn process_collisions(

--- a/src/gameplay/enemy.rs
+++ b/src/gameplay/enemy.rs
@@ -423,7 +423,7 @@ pub fn update_enemies(world: &mut World, resources: &Resources, dt: Duration) {
                             sat.shoot_timer.reset();
                             let norm_dir = dir.normalize();
                             missiles.push((
-                                t.translation + norm_dir * t.scale.x() * 2.0, // TODO better spawn points
+                                t.translation + norm_dir * t.scale.x * 2.0, // TODO better spawn points
                                 norm_dir,
                                 player,
                             ));

--- a/src/gameplay/pickup.rs
+++ b/src/gameplay/pickup.rs
@@ -95,14 +95,14 @@ pub fn aabb_intersection2(
     dbg!(transform1.translation + bb1.half_extend);
     dbg!(transform2.translation - bb2.half_extend);
     dbg!(transform2.translation + bb2.half_extend);
-    transform1.translation.x() - bb1.half_extend.x()
-        < transform2.translation.x() + bb2.half_extend.x()
-        && transform1.translation.x() + bb1.half_extend.x()
-            > transform2.translation.x() - bb2.half_extend.x()
-        && transform1.translation.y() - bb1.half_extend.y()
-            < transform2.translation.y() + bb2.half_extend.y()
-        && transform1.translation.y() + bb1.half_extend.y()
-            > transform2.translation.y() - bb2.half_extend.y()
+    transform1.translation.x - bb1.half_extend.x
+        < transform2.translation.x + bb2.half_extend.x
+        && transform1.translation.x + bb1.half_extend.x
+            > transform2.translation.x - bb2.half_extend.x
+        && transform1.translation.y - bb1.half_extend.y
+            < transform2.translation.y + bb2.half_extend.y
+        && transform1.translation.y + bb1.half_extend.y
+            > transform2.translation.y - bb2.half_extend.y
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug)]

--- a/src/gameplay/player.rs
+++ b/src/gameplay/player.rs
@@ -177,7 +177,7 @@ pub fn update_player(world: &mut World, dt: Duration, resources: &Resources) {
             // shoot from the top.
             let initial_pos = transform.translation
                 + glam::Mat2::from_angle(transform.rotation)
-                    * glam::vec2(0.0, transform.scale.y() / 2.0);
+                    * glam::vec2(0.0, transform.scale.y / 2.0);
 
             // calculate damages.
             let is_crit = player.stats.is_crit(random.rng());

--- a/src/gameplay/steering/mod.rs
+++ b/src/gameplay/steering/mod.rs
@@ -50,7 +50,7 @@ pub fn avoid(
         d: velocity.normalize(),
     };
 
-    let collisions = collision_world.ray_with_offset(ray, ignore_mask, transform.scale.x() / 2.0);
+    let collisions = collision_world.ray_with_offset(ray, ignore_mask, transform.scale.x / 2.0);
 
     let mut current_t = std::f32::INFINITY;
     let mut collision_data = None;
@@ -69,7 +69,7 @@ pub fn avoid(
 
     if let Some((_obstacle_pos, obstacle_center)) = collision_data {
         let d = (obstacle_center - transform.translation).length();
-        let avoidance_force = glam::vec2(velocity.y(), -velocity.x());
+        let avoidance_force = glam::vec2(velocity.y, -velocity.x);
         Some(avoidance_force.normalize() * avoidance_strength * look_ahead / d)
     } else {
         None

--- a/src/gameplay/trail.rs
+++ b/src/gameplay/trail.rs
@@ -21,7 +21,7 @@ pub fn update_trails(world: &mut World) {
             // );
 
             let dir = glam::Mat2::from_angle(transform.rotation) * glam::Vec2::unit_y();
-            emitter.position_offset = -dir * (trail.offset + transform.scale.y()) / 2.0;
+            emitter.position_offset = -dir * (trail.offset + transform.scale.y) / 2.0;
 
             emitter.enable();
         } else {

--- a/src/render/particle.rs
+++ b/src/render/particle.rs
@@ -267,8 +267,8 @@ impl ParticleEmitter {
                         let scale = match self.scale {
                             ParticleScale::Constant(s) => s,
                             ParticleScale::Random(low, high) => {
-                                let x = rng.gen_range(low.x(), high.x());
-                                let y = rng.gen_range(low.y(), high.y());
+                                let x = rng.gen_range(low.x, high.x);
+                                let y = rng.gen_range(low.y, high.y);
                                 glam::vec2(x, y)
                             }
                         };

--- a/src/render/path/debug.rs
+++ b/src/render/path/debug.rs
@@ -39,7 +39,7 @@ pub fn stroke_circle(resources: &Resources, position: glam::Vec2, radius: f32, c
             let mut geometry: VertexBuffers<Point, u16> = VertexBuffers::new();
             let color = color.to_normalized();
             if let Err(e) = basic_shapes::stroke_circle(
-                Point::new(position.x(), position.y()),
+                Point::new(position.x, position.y),
                 radius,
                 &StrokeOptions::default(),
                 &mut simple_builder(&mut geometry),
@@ -80,16 +80,16 @@ pub fn stroke_quad(
             let color = color.to_normalized();
 
             let p1 = position;
-            let p2 = position + glam::Vec2::unit_x() * dimensions.x();
+            let p2 = position + glam::Vec2::unit_x() * dimensions.x;
             let p3 = position
-                + glam::Vec2::unit_x() * dimensions.x()
-                + glam::Vec2::unit_y() * dimensions.y();
-            let p4 = position + glam::Vec2::unit_y() * dimensions.y();
+                + glam::Vec2::unit_x() * dimensions.x
+                + glam::Vec2::unit_y() * dimensions.y;
+            let p4 = position + glam::Vec2::unit_y() * dimensions.y;
             if let Err(e) = basic_shapes::stroke_quad(
-                Point::new(p1.x(), p1.y()),
-                Point::new(p2.x(), p2.y()),
-                Point::new(p3.x(), p3.y()),
-                Point::new(p4.x(), p4.y()),
+                Point::new(p1.x, p1.y),
+                Point::new(p2.x, p2.y),
+                Point::new(p3.x, p3.y),
+                Point::new(p4.x, p4.y),
                 &StrokeOptions::default(),
                 &mut simple_builder(&mut geometry),
             ) {
@@ -129,8 +129,8 @@ pub fn stroke_line(
             let color = color.to_normalized();
             if let Err(e) = basic_shapes::stroke_polyline(
                 vec![
-                    Point::new(position.x(), position.y()),
-                    Point::new(target.x(), target.y()),
+                    Point::new(position.x, position.y),
+                    Point::new(target.x, target.y),
                 ],
                 false,
                 &StrokeOptions::default(),

--- a/src/render/ui/gui.rs
+++ b/src/render/ui/gui.rs
@@ -43,8 +43,8 @@ impl GuiContext {
         match window_event {
             WindowEvent::MouseButton(btn, Action::Press, _) => self.mouse_clicked.push(btn),
             WindowEvent::CursorPos(x, y) => {
-                self.mouse_pos.set_x(x as f32);
-                self.mouse_pos.set_y(y as f32);
+                self.mouse_pos.x = x as f32;
+                self.mouse_pos.y = y as f32;
             }
             _ => (),
         }
@@ -153,7 +153,7 @@ impl Gui {
         let section = Section {
             text,
             scale,
-            screen_position: (0.0, 0.0), //(text_position.x(), text_position.y()),
+            screen_position: (0.0, 0.0), //(text_position.x, text_position.y),
             bounds: (
                 self.window_dim.width as f32 / 3.15,
                 self.window_dim.height as f32,

--- a/src/render/ui/text.rs
+++ b/src/render/ui/text.rs
@@ -147,8 +147,8 @@ where
 
         for (text, position) in text_data {
             // screen position is top-left origin
-            let pos_x = position.x();
-            let pos_y = position.y();
+            let pos_x = position.x;
+            let pos_y = position.y;
             debug!("Will display text at {}/{}", pos_x, pos_y);
 
             let scale = Scale::uniform(text.font_size.round());

--- a/src/render/ui/widgets/button.rs
+++ b/src/render/ui/widgets/button.rs
@@ -105,10 +105,10 @@ impl Button {
         };
 
         let mouse_pos_rel = ui.mouse_pos - self.anchor;
-        let is_above = mouse_pos_rel.x() >= 0.0
-            && mouse_pos_rel.x() < dimensions.x()
-            && mouse_pos_rel.y() >= 0.0
-            && mouse_pos_rel.y() <= dimensions.y();
+        let is_above = mouse_pos_rel.x >= 0.0
+            && mouse_pos_rel.x < dimensions.x
+            && mouse_pos_rel.y >= 0.0
+            && mouse_pos_rel.y <= dimensions.y;
         let color = self.background_color(ui, is_above);
         let text_color = self.text_color(ui, is_above);
         let (vertices, indices) = Panel {

--- a/src/render/ui/widgets/panel.rs
+++ b/src/render/ui/widgets/panel.rs
@@ -19,17 +19,17 @@ impl Panel {
 
         let w = window_dim.width as f32;
         let h = window_dim.height as f32;
-        let x = (self.anchor.x() / w) * 2.0 - 1.0;
-        let y = (1.0 - self.anchor.y() / h) * 2.0 - 1.0;
+        let x = (self.anchor.x / w) * 2.0 - 1.0;
+        let y = (1.0 - self.anchor.y / h) * 2.0 - 1.0;
         let top_left = glam::vec2(x, y);
         debug!("Anchor -> {:#?}", self.anchor);
         debug!("Top left -> {:#?}", top_left);
-        let dim = glam::vec2(2.0 * self.dimensions.x() / w, 2.0 * self.dimensions.y() / h);
+        let dim = glam::vec2(2.0 * self.dimensions.x / w, 2.0 * self.dimensions.y / h);
         debug!("Dimensions = {:?} => {:?}", self.dimensions, dim);
-        let top_right = top_left + dim.x() * glam::Vec2::unit_x();
+        let top_right = top_left + dim.x * glam::Vec2::unit_x();
         let bottom_right =
-            top_left + dim.x() * glam::Vec2::unit_x() - dim.y() * glam::Vec2::unit_y();
-        let bottom_left = top_left - dim.y() * glam::Vec2::unit_y();
+            top_left + dim.x * glam::Vec2::unit_x() - dim.y * glam::Vec2::unit_y();
+        let bottom_left = top_left - dim.y * glam::Vec2::unit_y();
 
         let color = self.color.to_normalized();
         (

--- a/src/scene/story.rs
+++ b/src/scene/story.rs
@@ -63,7 +63,7 @@ where
 
         if self.timer_before_instruction.finished() {
             gui.centered_label(
-                glam::Vec2::new(window_dim.x() / 2.0, window_dim.y() - 60.0),
+                glam::Vec2::new(window_dim.x / 2.0, window_dim.y - 60.0),
                 "Press Enter to continue...".to_string(),
             );
         }


### PR DESCRIPTION
This PR bumps most dependencies. Only image and glam needed code change, the former for a simple deprecated alias, the latter for `.x()` and `.set_x()` having been merged into `.x` (resp. `.y` and `.z`).

I’ve also removed support for image formats other than PNG and sound formats other than WAVE and MP3, which only bloat the final binary with unused code (reducing it from 6.1 MiB to 4.9 MiB). Overall this also reduces the build times by 12%, and number of built crates from 233 to 202.