### PR TITLE
Mention the AUR package for ArchLinux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 Space shooter/Bullet hell made for Game Off 2020.
 
 [Link to project](https://snoozetime.itch.io/everfight-gameoff2020)
+
+## Packages
+
+* ArchLinux: install [everfight-git from AUR](https://aur.archlinux.org/packages/everfight-git)


### PR DESCRIPTION
[AUR](https://aur.archlinux.org) is the place where ArchLinux users go to find packages which aren’t directly included in their distribution.

I’m now maintaining [a package of your game there](https://aur.archlinux.org/packages/everfight-git), with only two differences compared to master:
- I’ve disabled the `glfw-sys` feature of glfw-rs, in order to support Wayland instead of forcing the user to use X11.
- I’ve also made the assets path default to `/usr/share/everfight`, where this package stores them.

If you are interested, I could make you a package [on Flathub](https://flathub.org) too. :)